### PR TITLE
feat(dynamic-layers): soporta vector tiles dinámicos protegidos

### DIFF
--- a/src/components/SheetsMap.vue
+++ b/src/components/SheetsMap.vue
@@ -405,6 +405,7 @@ export default {
             default_attribution:
                 '&copy; <a target="_blank" href="http://osm.org/copyright">OpenStreetMap</a> contributors',
             zoom: 7,
+            external_view_override: false,
             center_default: [-33.472, -70.769],
             center: undefined,
             center_parsed: "",
@@ -648,6 +649,7 @@ export default {
                 /** Establecer un nivel de zoom específico (0-20) */
                 setZoom: (level) => {
                     const z = Math.max(0, Math.min(20, level));
+                    this.external_view_override = true;
                     this.zoom = z;
                 },
                 /** Obtener el nivel de zoom actual */
@@ -656,6 +658,8 @@ export default {
                 flyTo: (latLng, zoom) => this.zoomToLocation(latLng, zoom),
                 /** Centrar el mapa en { lat, lng } sin animación */
                 panTo: (latLng) => {
+                    this.external_view_override = true;
+                    this.center = latLng;
                     if (this.map) this.map.panTo(latLng);
                 },
                 /** Filtrar por zona visible del mapa */
@@ -1474,8 +1478,11 @@ export default {
             this.$delete(this.vector_tile_legends, layerId);
         },
         zoomToLocation(latLng, zoom) {
+            this.external_view_override = true;
             this.searchMarkerLatLng = latLng;
             this.shouldShowSearchMarker = true;
+            this.center = latLng;
+            this.zoom = zoom || 12;
             this.map.flyTo(latLng, zoom || 12);
         },
         zoomMap(zoom) {
@@ -2441,16 +2448,18 @@ export default {
                         this.col_lng = data.sh_map_column_longitude;
                         this.col_lat = data.sh_map_column_latitude;
 
-                        if (this.getCoordsFromUrlParams()) {
-                            this.center = this.getCoordsFromUrlParams();
-                        } else if (data.latitud_map_center && data.longitud_map_center) {
-                            this.center = [data.latitud_map_center, data.longitud_map_center];
-                        } else {
-                            // Coordenadas para Santiago de Chile - Chile\
-                            this.center = this.center_default;
-                        }
+                        if (!this.external_view_override) {
+                            if (this.getCoordsFromUrlParams()) {
+                                this.center = this.getCoordsFromUrlParams();
+                            } else if (data.latitud_map_center && data.longitud_map_center) {
+                                this.center = [data.latitud_map_center, data.longitud_map_center];
+                            } else {
+                                // Coordenadas para Santiago de Chile - Chile\
+                                this.center = this.center_default;
+                            }
 
-                        this.zoom = data.sh_map_zoom ? data.sh_map_zoom : 7;
+                            this.zoom = data.sh_map_zoom ? data.sh_map_zoom : 7;
+                        }
                     } catch (error) {
                         console.error(error);
 

--- a/src/components/SheetsMap.vue
+++ b/src/components/SheetsMap.vue
@@ -345,6 +345,13 @@ Icon.Default.mergeOptions({
 import ScreenshotButton from "./ScreenshotButton.vue";
 
 const sheetsMapVersion = packageInfo.version;
+const DEFAULT_MAP_CENTER = Object.freeze([-33.472, -70.769]);
+const INVALID_MAP_CONFIG_VALUES = new Set(["", "null", "undefined"]);
+
+function hasValidMapConfigValue(value) {
+    if (value === null || value === undefined) return false;
+    return !INVALID_MAP_CONFIG_VALUES.has(String(value).trim().toLowerCase());
+}
 
 export default {
     name: "SheetsMap",
@@ -406,8 +413,8 @@ export default {
                 '&copy; <a target="_blank" href="http://osm.org/copyright">OpenStreetMap</a> contributors',
             zoom: 7,
             external_view_override: false,
-            center_default: [-33.472, -70.769],
-            center: undefined,
+            center_default: [...DEFAULT_MAP_CENTER],
+            center: [...DEFAULT_MAP_CENTER],
             center_parsed: "",
             center_format: "latlng",
             col_lat: undefined,
@@ -436,6 +443,7 @@ export default {
             vector_tile_legends: {},
             dynamic_layer_registry: {},
             dynamic_layer_render_token: 0,
+            map_configuration_ready: false,
             end_map_move: false,
             end_map_pressure: false,
             bounds_filters: [],
@@ -640,32 +648,111 @@ export default {
          *   }
          *   // luego:  this.mapActions.zoomIn()
          */
-        mapActions() {
+        mapActionContracts() {
             return {
+                setZoom: {
+                    invocation: { type: "payload" },
+                    required: ["level"],
+                    payload: {
+                        level: "number",
+                        options: {
+                            externalOverride: "boolean",
+                        },
+                    },
+                },
+                flyTo: {
+                    invocation: { type: "payload" },
+                    required: ["latLng"],
+                    payload: {
+                        latLng: "LatLng",
+                        zoom: "number",
+                        options: {
+                            showMarker: "boolean",
+                            externalOverride: "boolean",
+                            leaflet: "object",
+                        },
+                    },
+                },
+                panTo: {
+                    invocation: { type: "payload" },
+                    required: ["latLng"],
+                    payload: {
+                        latLng: "LatLng",
+                        options: {
+                            externalOverride: "boolean",
+                            leaflet: "object",
+                        },
+                    },
+                },
+                drawShape: {
+                    invocation: { type: "payload" },
+                    required: ["shape"],
+                    payload: {
+                        shape: "polygon|circle|rectangle|delete|cancel|clear",
+                    },
+                },
+                setEraserMode: {
+                    invocation: { type: "payload" },
+                    required: ["active"],
+                    payload: {
+                        active: "boolean",
+                    },
+                },
+            };
+        },
+        mapActions() {
+            const contracts = this.mapActionContracts;
+
+            return {
+                contracts,
+                getContracts: () => contracts,
+                isConfigurationReady: () => this.map_configuration_ready,
                 /** Acercar el zoom del mapa en 1 nivel */
                 zoomIn: () => this.zoomMap("in"),
                 /** Alejar el zoom del mapa en 1 nivel */
                 zoomOut: () => this.zoomMap("out"),
                 /** Establecer un nivel de zoom específico (0-20) */
-                setZoom: (level) => {
+                setZoom: (payload = {}) => {
+                    const level = payload?.level;
+                    const options = payload?.options || {};
+                    if (typeof level !== "number") return;
+
                     const z = Math.max(0, Math.min(20, level));
-                    this.external_view_override = true;
+                    if (options.externalOverride !== false) {
+                        this.external_view_override = true;
+                    }
                     this.zoom = z;
                 },
                 /** Obtener el nivel de zoom actual */
                 getZoom: () => this.zoom,
                 /** Volar a una ubicación { lat, lng } con zoom opcional (default 12) */
-                flyTo: (latLng, zoom) => this.zoomToLocation(latLng, zoom),
+                flyTo: (payload = {}) =>
+                    payload?.latLng
+                        ? this.zoomToLocation(
+                              payload.latLng,
+                              payload?.zoom,
+                              payload?.options || {},
+                          )
+                        : undefined,
                 /** Centrar el mapa en { lat, lng } sin animación */
-                panTo: (latLng) => {
-                    this.external_view_override = true;
+                panTo: (payload = {}) => {
+                    const latLng = payload?.latLng;
+                    const options = payload?.options || {};
+                    if (!latLng) return;
+
+                    if (options.externalOverride !== false) {
+                        this.external_view_override = true;
+                    }
                     this.center = latLng;
-                    if (this.map) this.map.panTo(latLng);
+                    if (this.map) this.map.panTo(latLng, options.leaflet || {});
                 },
                 /** Filtrar por zona visible del mapa */
                 filterByBounds: () => this.filter(),
                 /** Iniciar trazo de polígono ('polygon', 'circle', 'rectangle') o 'delete' */
-                drawShape: (shape) => this.polygonAction(shape),
+                drawShape: (payload = {}) => {
+                    if (!payload?.shape) return;
+                    this.polygonAction(payload.shape);
+                },
                 /** Cambiar formato de coordenadas (latlng / UTM) */
                 toggleCoordinateFormat: () => this.changeCoordinateFormat(),
                 /** Obtener las coordenadas del centro actual */
@@ -712,7 +799,10 @@ export default {
                 /** Activar/desactivar el modo borrador (toggle) */
                 toggleEraserMode: () => this.polygonAction("delete"),
                 /** Activar o desactivar el modo borrador de forma idempotente */
-                setEraserMode: (active) => {
+                setEraserMode: (payload = {}) => {
+                    if (typeof payload?.active !== "boolean") return;
+
+                    const active = Boolean(payload?.active);
                     const d = this.$refs.polygon_drafter;
                     if (d && d.buttons_pressed.delete !== active)
                         this.polygonAction("delete");
@@ -1262,9 +1352,6 @@ export default {
         // TO DO:
         // Colocar primera capa base encontrada
 
-        //Alguna parte del mar del Pacifico Sur
-        this.center = [-45.7247315, -108.8552016];
-
         this.getMapConfiguration();
         // Cuando geo_json es construido, se instancia Supercluster
     },
@@ -1477,13 +1564,33 @@ export default {
 
             this.$delete(this.vector_tile_legends, layerId);
         },
-        zoomToLocation(latLng, zoom) {
-            this.external_view_override = true;
+        zoomToLocation(latLng, zoom, options = {}) {
+            if (options.externalOverride !== false) {
+                this.external_view_override = true;
+            }
             this.searchMarkerLatLng = latLng;
-            this.shouldShowSearchMarker = true;
-            this.center = latLng;
-            this.zoom = zoom || 12;
-            this.map.flyTo(latLng, zoom || 12);
+            this.shouldShowSearchMarker = options.showMarker !== false;
+
+            const targetZoom = zoom || 12;
+            if (!this.map || typeof this.map.flyTo !== "function") {
+                this.center = latLng;
+                this.zoom = targetZoom;
+                return;
+            }
+
+            this.map.once("moveend", () => {
+                this.center = latLng;
+                this.zoom = targetZoom;
+
+                if (this.map.getZoom() !== targetZoom) {
+                    this.map.setView(latLng, targetZoom, { animate: false });
+                }
+            });
+
+            this.map.flyTo(latLng, targetZoom, {
+                duration: 1.2,
+                ...(options.leaflet || {}),
+            });
         },
         zoomMap(zoom) {
             if (zoom === "out") this.zoom--;
@@ -2432,8 +2539,26 @@ export default {
         setTileLayer() {
             this.url = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png";
         },
+        notifyMapConfigurationReady() {
+            this.map_configuration_ready = true;
+            this.$emit("map-configuration-ready", this.mapActions);
+        },
         getMapConfiguration() {
             //data
+            if (
+                !hasValidMapConfigValue(this.endpoint_config) ||
+                !hasValidMapConfigValue(this.config_entity_type_id) ||
+                !hasValidMapConfigValue(this.config_entity_id)
+            ) {
+                console.warn("[SheetsMap] getMapConfiguration skipped: invalid map configuration context", {
+                    endpoint_config: this.endpoint_config,
+                    config_entity_type_id: this.config_entity_type_id,
+                    config_entity_id: this.config_entity_id,
+                });
+                this.notifyMapConfigurationReady();
+                return;
+            }
+
             const url = `${this.base_url}${this.endpoint_config}${this.config_entity_type_id}/${this.config_entity_id}?page=1&set_alias=alias`;
 
             let all_data;
@@ -2464,13 +2589,16 @@ export default {
                         console.error(error);
 
                         // Coordenadas para Santiago de Chile - Chile
-                        this.center = this.center_default;
+                        if (!this.external_view_override) {
+                            this.center = this.center_default;
+                        }
                     }
                 })
                 .catch((error) => {
                     console.error(error);
                 })
                 .finally(() => {
+                    this.notifyMapConfigurationReady();
                     console.log("done data");
                 });
         },

--- a/src/components/SheetsMap.vue
+++ b/src/components/SheetsMap.vue
@@ -120,7 +120,7 @@
                 <!-- Vector Tile Layers (MapLibre GL) -->
                 <!-- Las capas se renderizan en orden de array: primera = fondo, última = tope -->
                 <!-- El _uid asegura que Vue destruya y recree componentes correctamente -->
-                <vector-tile-layer v-for="vectorTile in operative_vector_tiles_xyz" :key="vectorTile._uid" :map="map"
+                <vector-tile-layer v-for="vectorTile in renderable_vector_tiles_xyz" :key="vectorTile._uid" :map="map"
                     :layer="vectorTile.layer" :info="info" :visible_columns="vectorTile.visible_columns"
                     :entity_type_id="vectorTile.entity_type_id" :base_url="base_url"
                     @feature-click="handleVectorTileFeatureClick" @legend-ready="handleVectorTileLegendReady"
@@ -316,6 +316,12 @@ import VectorTileLegend from "./layers/VectorTileLegend.vue";
 import PolygonDrafter from "./PolygonDrafter.vue";
 import "leaflet/dist/leaflet.css";
 import { Icon } from "leaflet";
+import {
+    normalizePublicLayerDefinition,
+    applyPublicLayerPatch,
+    buildVectorTileLayerPayload,
+    DYNAMIC_LAYER_TYPES,
+} from "../utils/dynamicLayers";
 import axios from "axios";
 import HeatmapOverlay from "heatmap.js/plugins/leaflet-heatmap";
 import { BButton, BIcon, BPopover } from "bootstrap-vue";
@@ -427,6 +433,8 @@ export default {
             operative_geoserver_wms: [],
             operative_vector_tiles_xyz: [],
             vector_tile_legends: {},
+            dynamic_layer_registry: {},
+            dynamic_layer_render_token: 0,
             end_map_move: false,
             end_map_pressure: false,
             bounds_filters: [],
@@ -705,6 +713,48 @@ export default {
                     if (d && d.buttons_pressed.delete !== active)
                         this.polygonAction("delete");
                 },
+                /** Agrega o reemplaza una capa dinámica usando una definición pública genérica */
+                addLayer: (definition) => this.addPublicLayer(definition),
+                /** Indica si una capa dinámica agregada por API existe */
+                hasLayer: (payload) =>
+                    this.hasPublicLayer(
+                        typeof payload === "string" ? payload : payload?.layerId,
+                    ),
+                /** Retorna la definición normalizada y payload renderizable de una capa dinámica */
+                getLayer: (payload) =>
+                    this.getPublicLayer(
+                        typeof payload === "string" ? payload : payload?.layerId,
+                    ),
+                /** Elimina una capa dinámica por id */
+                removeLayer: (payload) =>
+                    this.removePublicLayer(
+                        typeof payload === "string" ? payload : payload?.layerId,
+                    ),
+                /** Actualiza parcialmente una capa dinámica existente */
+                updateLayer: (payload) =>
+                    this.updatePublicLayer(payload?.layerId, payload?.patch || {}),
+                /** Aplica un renderState a una capa dinámica existente */
+                setLayerRenderState: (payload) =>
+                    this.setPublicLayerRenderState(payload?.layerId, payload?.renderState),
+                /** Controla visibilidad lógica de una capa dinámica existente */
+                setLayerVisibility: (payload) =>
+                    this.setPublicLayerVisibility(payload?.layerId, payload?.visible),
+                /** Controla opacidad lógica de una capa dinámica existente */
+                setLayerOpacity: (payload) =>
+                    this.setPublicLayerOpacity(payload?.layerId, payload?.opacity),
+                /** Establece orden relativo para capas dinámicas */
+                setLayerOrder: (payload) =>
+                    this.setPublicLayerOrder(payload?.layerId, payload?.order),
+                /** Envía una capa dinámica al fondo del stack dinámico */
+                sendLayerToBack: (payload) =>
+                    this.sendPublicLayerToBack(
+                        typeof payload === "string" ? payload : payload?.layerId,
+                    ),
+                /** Lleva una capa dinámica al frente del stack dinámico */
+                bringLayerToFront: (payload) =>
+                    this.bringPublicLayerToFront(
+                        typeof payload === "string" ? payload : payload?.layerId,
+                    ),
             };
         },
         btn_style() {
@@ -1072,6 +1122,20 @@ export default {
 
             return active_layers;
         },
+        renderable_vector_tiles_xyz() {
+            return [...this.operative_vector_tiles_xyz]
+                .filter((entry) => entry && entry.visible !== false)
+                .sort((left, right) => {
+                    const leftOrder = Number.isFinite(left?.order)
+                        ? left.order
+                        : Number.MAX_SAFE_INTEGER;
+                    const rightOrder = Number.isFinite(right?.order)
+                        ? right.order
+                        : Number.MAX_SAFE_INTEGER;
+                    if (leftOrder !== rightOrder) return leftOrder - rightOrder;
+                    return 0;
+                });
+        },
         disabled_layers() {
             if (_.isEmpty(this.layers)) {
                 return [];
@@ -1204,6 +1268,144 @@ export default {
         this.poweredCoderhub();
     },
     methods: {
+        nextDynamicLayerOrder() {
+            const dynamicEntries = Object.values(this.dynamic_layer_registry || {});
+            if (dynamicEntries.length === 0) return 0;
+            return dynamicEntries.reduce((maxOrder, entry) => {
+                const order = Number.isFinite(entry?.definition?.order)
+                    ? entry.definition.order
+                    : 0;
+                return Math.max(maxOrder, order);
+            }, 0) + 1;
+        },
+        hasPublicLayer(layerId) {
+            return Boolean(layerId && this.dynamic_layer_registry[layerId]);
+        },
+        getPublicLayer(layerId) {
+            return this.dynamic_layer_registry[layerId] || null;
+        },
+        rebuildDynamicVectorTileRegistryView() {
+            const staticEntries = this.operative_vector_tiles_xyz.filter(
+                (entry) => !entry || entry._dynamic !== true,
+            );
+            const dynamicEntries = Object.values(this.dynamic_layer_registry || {})
+                .filter((entry) => entry && entry.payload)
+                .map((entry) => entry.payload);
+            this.operative_vector_tiles_xyz = [...staticEntries, ...dynamicEntries];
+        },
+        upsertDynamicVectorTileLayer(normalizedDefinition) {
+            const safeDefinition = {
+                ...normalizedDefinition,
+                visible:
+                    typeof normalizedDefinition.visible === "boolean"
+                        ? normalizedDefinition.visible
+                        : true,
+                order:
+                    Number.isFinite(normalizedDefinition.order)
+                        ? normalizedDefinition.order
+                        : this.hasPublicLayer(normalizedDefinition.id)
+                            ? this.dynamic_layer_registry[normalizedDefinition.id].definition.order
+                            : this.nextDynamicLayerOrder(),
+            };
+            const payload = {
+                ...buildVectorTileLayerPayload(safeDefinition),
+                _uid: `${safeDefinition.id}-${Date.now()}-${Math.random()}`,
+            };
+            const nextRecord = {
+                definition: safeDefinition,
+                payload,
+                inserted_at: Date.now(),
+            };
+
+            this.$set(this.dynamic_layer_registry, safeDefinition.id, nextRecord);
+            this.rebuildDynamicVectorTileRegistryView();
+            return payload;
+        },
+        addPublicLayer(definition) {
+            const normalizedDefinition = normalizePublicLayerDefinition(definition);
+
+            switch (normalizedDefinition.type) {
+                case DYNAMIC_LAYER_TYPES.VECTOR_TILE:
+                    return this.upsertDynamicVectorTileLayer(normalizedDefinition);
+                default:
+                    throw new Error(
+                        `Tipo de capa no soportado por addLayer: ${normalizedDefinition.type}`,
+                    );
+            }
+        },
+        removePublicLayer(layerId) {
+            if (!this.hasPublicLayer(layerId)) {
+                return false;
+            }
+            const record = this.dynamic_layer_registry[layerId];
+            this.$delete(this.dynamic_layer_registry, layerId);
+            this.rebuildDynamicVectorTileRegistryView();
+            return record;
+        },
+        updatePublicLayer(layerId, patch) {
+            const record = this.getPublicLayer(layerId);
+            if (!record) {
+                throw new Error(`La capa dinámica ${layerId} no existe.`);
+            }
+
+            const nextDefinition = applyPublicLayerPatch(record.definition, patch);
+            switch (nextDefinition.type) {
+                case DYNAMIC_LAYER_TYPES.VECTOR_TILE:
+                    return this.upsertDynamicVectorTileLayer(nextDefinition);
+                default:
+                    throw new Error(
+                        `Tipo de capa no soportado por updateLayer: ${nextDefinition.type}`,
+                    );
+            }
+        },
+        setPublicLayerRenderState(layerId, renderState) {
+            const record = this.getPublicLayer(layerId);
+            if (!record) {
+                throw new Error(`La capa dinámica ${layerId} no existe.`);
+            }
+
+            const nextDefinition = {
+                ...record.definition,
+                renderState,
+            };
+            const nextPayload = {
+                ...record.payload,
+                layer: {
+                    ...record.payload.layer,
+                    sh_map_has_layer_render_state: renderState,
+                },
+            };
+
+            this.$set(this.dynamic_layer_registry, layerId, {
+                ...record,
+                definition: nextDefinition,
+                payload: nextPayload,
+            });
+            this.rebuildDynamicVectorTileRegistryView();
+            return nextPayload;
+        },
+        setPublicLayerVisibility(layerId, visible) {
+            return this.updatePublicLayer(layerId, { visible });
+        },
+        setPublicLayerOpacity(layerId, opacity) {
+            return this.updatePublicLayer(layerId, { opacity });
+        },
+        setPublicLayerOrder(layerId, order) {
+            return this.updatePublicLayer(layerId, { order });
+        },
+        bringPublicLayerToFront(layerId) {
+            return this.setPublicLayerOrder(layerId, this.nextDynamicLayerOrder());
+        },
+        sendPublicLayerToBack(layerId) {
+            const dynamicEntries = Object.values(this.dynamic_layer_registry || {});
+            const minOrder = dynamicEntries.reduce((acc, entry) => {
+                const order = Number.isFinite(entry?.definition?.order)
+                    ? entry.definition.order
+                    : 0;
+                return Math.min(acc, order);
+            }, 0);
+            return this.setPublicLayerOrder(layerId, minOrder - 1);
+        },
         classification_icon(id = null) {
             let classification_icon;
             let classification_icon_info;

--- a/src/components/layers/VectorTileLayer.vue
+++ b/src/components/layers/VectorTileLayer.vue
@@ -66,6 +66,12 @@ export default {
             if (!oldMap && newMap && !this.isInitialized) {
                 this.createVectorTileLayer();
             }
+        },
+        'layer.sh_map_has_layer_render_state': {
+            deep: true,
+            handler() {
+                this.applyRenderStateToLiveLayer();
+            }
         }
     },
     mounted() {
@@ -178,6 +184,15 @@ export default {
             };
 
             this.emitLegend(renderState.legend);
+
+            const requestHeaders =
+                this.layer.sh_map_request_headers && typeof this.layer.sh_map_request_headers === 'object'
+                    ? this.layer.sh_map_request_headers
+                    : {};
+            const requestAuthMode =
+                typeof this.layer.sh_map_request_auth_mode === 'string'
+                    ? this.layer.sh_map_request_auth_mode
+                    : '';
             
             // Crear la capa MapLibre GL como capa de Leaflet
             this.vectorTileLayer = L.maplibreGL({
@@ -192,7 +207,27 @@ export default {
                 canvasContextAttributes: {
                     preserveDrawingBuffer: true,  // CRÍTICO para html2canvas: Preservar buffer para permitir captura
                     antialias: true,  // Mejorar calidad del rendering
-                }
+                },
+                transformRequest: (url) => {
+                    const headers = {
+                        ...requestHeaders,
+                    };
+                    const runtimeAuth = window.__OGP_RUNTIME_AUTH__ || {};
+                    if (
+                        requestAuthMode === 'ogp-bearer' &&
+                        typeof runtimeAuth.getBearerToken === 'function'
+                    ) {
+                        const runtimeToken = runtimeAuth.getBearerToken();
+                        if (typeof runtimeToken === 'string' && runtimeToken.length > 0) {
+                            headers.Authorization = `Bearer ${runtimeToken}`;
+                        }
+                    }
+
+                    return {
+                        url,
+                        headers,
+                    };
+                },
             });
             
             // Agregar la capa al mapa
@@ -246,11 +281,25 @@ export default {
         },
 
         async resolveRenderState(tileUrl) {
+            const explicitRenderState = this.layer.sh_map_has_layer_render_state;
             const defaultRenderState = {
-                styleExpressions: buildDefaultVectorTilePaint(this.layer),
+                styleExpressions:
+                    explicitRenderState?.styleExpressions ||
+                    buildDefaultVectorTilePaint(this.layer),
                 legend: null,
-                sourceLayerHint: null,
+                sourceLayerHint:
+                    explicitRenderState?.sourceLayerHint ||
+                    this.layer.sh_map_has_layer_vector_source_layer ||
+                    null,
             };
+
+            if (explicitRenderState?.legend) {
+                defaultRenderState.legend = explicitRenderState.legend;
+            }
+
+            if (explicitRenderState?.styleExpressions) {
+                return defaultRenderState;
+            }
 
             const legendConfig = normalizeVectorTileLegendConfig(this.layer);
 
@@ -281,6 +330,11 @@ export default {
         },
 
         emitLegend(legend) {
+            const legendMode = this.layer.sh_map_has_layer_legend_mode || 'internal';
+            if (legendMode === 'external' || legendMode === 'none') {
+                this.$emit('legend-clear', this.layer.id);
+                return;
+            }
             if (!legend || legend.visible === false) {
                 this.$emit('legend-clear', this.layer.id);
                 return;
@@ -290,6 +344,90 @@ export default {
                 layerId: this.layer.id,
                 legend,
             });
+        },
+
+        resolveStylePaint(styleExpressions = null) {
+            const resolvedStyleExpressions = styleExpressions || buildDefaultVectorTilePaint(this.layer);
+            const fillColorExpression = resolvedStyleExpressions.fillColorExpression;
+            const strokeColorExpression = resolvedStyleExpressions.strokeColorExpression;
+
+            return {
+                fillColorExpression,
+                strokeColorExpression,
+                pointRadiusExpression: resolvedStyleExpressions.pointRadiusExpression ?? 8,
+                pointStrokeWidthExpression: resolvedStyleExpressions.pointStrokeWidthExpression ?? 3,
+                polygonFillOpacityExpression: resolvedStyleExpressions.polygonFillOpacityExpression ?? 0.6,
+                polygonStrokeWidthExpression: resolvedStyleExpressions.polygonStrokeWidthExpression ?? 2,
+                polygonStrokeOpacityExpression: resolvedStyleExpressions.polygonStrokeOpacityExpression ?? 0.8,
+                lineWidthExpression: resolvedStyleExpressions.lineWidthExpression ?? 2.5,
+                lineOpacityExpression: resolvedStyleExpressions.lineOpacityExpression ?? 0.85,
+                useSymbolForPointShape: Boolean(
+                    resolvedStyleExpressions.useSymbolForPointShape && !this.layer.sh_map_has_layer_point_image
+                ),
+                legendItems: resolvedStyleExpressions.legendItems || [],
+                legendAttribute: resolvedStyleExpressions.legendAttribute,
+                defaultFillColor: resolvedStyleExpressions.defaultFillColor || '#3388ff',
+                defaultStrokeColor: resolvedStyleExpressions.defaultStrokeColor || '#3388ff',
+            };
+        },
+
+        setPaintPropertyIfExists(layerId, property, value) {
+            if (!this.maplibreMap || !this.maplibreMap.getLayer(layerId)) return;
+            this.maplibreMap.setPaintProperty(layerId, property, value);
+        },
+
+        setLayoutPropertyIfExists(layerId, property, value) {
+            if (!this.maplibreMap || !this.maplibreMap.getLayer(layerId)) return;
+            this.maplibreMap.setLayoutProperty(layerId, property, value);
+        },
+
+        applyStyleExpressionsToLiveLayer(styleExpressions = null) {
+            if (!this.maplibreMap) return;
+
+            const paint = this.resolveStylePaint(styleExpressions);
+
+            this.setPaintPropertyIfExists(`${this.layer.id}-fill`, 'fill-color', paint.fillColorExpression);
+            this.setPaintPropertyIfExists(`${this.layer.id}-fill`, 'fill-opacity', paint.polygonFillOpacityExpression);
+
+            this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-color', paint.strokeColorExpression);
+            this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-width', paint.polygonStrokeWidthExpression);
+            this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-opacity', paint.polygonStrokeOpacityExpression);
+
+            this.setPaintPropertyIfExists(`${this.layer.id}-line`, 'line-color', paint.fillColorExpression);
+            this.setPaintPropertyIfExists(`${this.layer.id}-line`, 'line-width', paint.lineWidthExpression);
+            this.setPaintPropertyIfExists(`${this.layer.id}-line`, 'line-opacity', paint.lineOpacityExpression);
+
+            [`${this.layer.id}-circle`, `${this.layer.id}-circle-fallback`].forEach((layerId) => {
+                this.setPaintPropertyIfExists(layerId, 'circle-radius', paint.pointRadiusExpression);
+                this.setPaintPropertyIfExists(layerId, 'circle-color', paint.fillColorExpression);
+                this.setPaintPropertyIfExists(layerId, 'circle-stroke-width', paint.pointStrokeWidthExpression);
+                this.setPaintPropertyIfExists(layerId, 'circle-stroke-color', paint.strokeColorExpression);
+            });
+
+            if (paint.useSymbolForPointShape) {
+                this.setLayoutPropertyIfExists(
+                    `${this.layer.id}-symbol`,
+                    'icon-image',
+                    this.buildColoredShapeIconExpression(
+                        paint.legendAttribute,
+                        paint.legendItems,
+                        paint.defaultFillColor,
+                        paint.defaultStrokeColor
+                    )
+                );
+                this.setLayoutPropertyIfExists(`${this.layer.id}-symbol`, 'icon-size', ['/', paint.pointRadiusExpression, 32]);
+            }
+        },
+
+        async applyRenderStateToLiveLayer() {
+            if (!this.maplibreMap || !this.isInitialized) return;
+
+            const tileUrl = this.tileUrl || this.layer.sh_map_has_layer_url || '';
+            const renderState = await this.resolveRenderState(tileUrl);
+            if (this.isDestroyed()) return;
+
+            this.applyStyleExpressionsToLiveLayer(renderState.styleExpressions);
+            this.emitLegend(renderState.legend);
         },
         
         /**
@@ -598,14 +736,7 @@ export default {
         
         createMapLibreLayers(styleExpressions = null) {
             const layers = [];
-            const resolvedStyleExpressions = styleExpressions || buildDefaultVectorTilePaint(this.layer);
-            const fillColorExpression = resolvedStyleExpressions.fillColorExpression;
-            const strokeColorExpression = resolvedStyleExpressions.strokeColorExpression;
-            const pointRadiusExpression = resolvedStyleExpressions.pointRadiusExpression || 8;
-            const pointStrokeWidthExpression = resolvedStyleExpressions.pointStrokeWidthExpression || 3;
-            const useSymbolForPointShape = Boolean(
-                resolvedStyleExpressions.useSymbolForPointShape && !this.layer.sh_map_has_layer_point_image
-            );
+            const paint = this.resolveStylePaint(styleExpressions);
             
             // Capa para polígonos
             layers.push({
@@ -615,8 +746,8 @@ export default {
                 'source-layer': this.sourceLayer,
                 filter: ['==', '$type', 'Polygon'],
                 paint: {
-                    'fill-color': fillColorExpression,
-                    'fill-opacity': 0.6
+                    'fill-color': paint.fillColorExpression,
+                    'fill-opacity': paint.polygonFillOpacityExpression
                 }
             });
             
@@ -628,9 +759,9 @@ export default {
                 'source-layer': this.sourceLayer,
                 filter: ['==', '$type', 'Polygon'],
                 paint: {
-                    'line-color': strokeColorExpression,
-                    'line-width': 2,
-                    'line-opacity': 0.8
+                    'line-color': paint.strokeColorExpression,
+                    'line-width': paint.polygonStrokeWidthExpression,
+                    'line-opacity': paint.polygonStrokeOpacityExpression
                 }
             });
 
@@ -643,9 +774,9 @@ export default {
                 'source-layer': this.sourceLayer,
                 filter: ['==', '$type', 'LineString'],
                 paint: {
-                    'line-color': fillColorExpression,
-                    'line-width': 2.5,
-                    'line-opacity': 0.85
+                    'line-color': paint.fillColorExpression,
+                    'line-width': paint.lineWidthExpression,
+                    'line-opacity': paint.lineOpacityExpression
                 }
             });
             
@@ -680,14 +811,14 @@ export default {
                         'icon-ignore-placement': true
                     }
                 });
-            } else if (useSymbolForPointShape) {
+            } else if (paint.useSymbolForPointShape) {
                 // Formas custom via imágenes canvas con colores baked-in (NO SDF).
                 // Las imágenes se generan instantáneamente via styleimagemissing.
                 this.pointRenderMode = 'symbol';
-                const legendItems = resolvedStyleExpressions.legendItems || [];
-                const legendAttribute = resolvedStyleExpressions.legendAttribute;
-                const defaultFill = resolvedStyleExpressions.defaultFillColor || '#3388ff';
-                const defaultStroke = resolvedStyleExpressions.defaultStrokeColor || '#3388ff';
+                const legendItems = paint.legendItems;
+                const legendAttribute = paint.legendAttribute;
+                const defaultFill = paint.defaultFillColor;
+                const defaultStroke = paint.defaultStrokeColor;
 
                 // Symbol layer con iconos de formas coloreadas
                 layers.push({
@@ -700,7 +831,7 @@ export default {
                         'icon-image': this.buildColoredShapeIconExpression(
                             legendAttribute, legendItems, defaultFill, defaultStroke
                         ),
-                        'icon-size': ['/', pointRadiusExpression, 32],
+                        'icon-size': ['/', paint.pointRadiusExpression, 32],
                         'icon-allow-overlap': true,
                         'icon-ignore-placement': true,
                     }
@@ -715,10 +846,10 @@ export default {
                     'source-layer': this.sourceLayer,
                     filter: this.pointGeometryFilter(),
                     paint: {
-                        'circle-radius': pointRadiusExpression,
-                        'circle-color': fillColorExpression, // Color dinámico desde 'Fill'
-                        'circle-stroke-width': pointStrokeWidthExpression,
-                        'circle-stroke-color': strokeColorExpression, // Color dinámico desde 'Stroke'
+                        'circle-radius': paint.pointRadiusExpression,
+                        'circle-color': paint.fillColorExpression, // Color dinámico desde 'Fill'
+                        'circle-stroke-width': paint.pointStrokeWidthExpression,
+                        'circle-stroke-color': paint.strokeColorExpression, // Color dinámico desde 'Stroke'
                         'circle-opacity': 1.0
                     }
                 });

--- a/src/utils/dynamicLayers.js
+++ b/src/utils/dynamicLayers.js
@@ -1,0 +1,270 @@
+const DYNAMIC_VECTOR_TILE_CODE = "operative_vector_tiles_xyz";
+
+function normalizeId(rawId) {
+    if (typeof rawId !== "string") {
+        return "";
+    }
+
+    return rawId.trim();
+}
+
+function normalizeString(value, fallback = "") {
+    if (typeof value !== "string") {
+        return fallback;
+    }
+
+    return value.trim();
+}
+
+function normalizeSourceLayer(value) {
+    return normalizeString(value);
+}
+
+function normalizeSource(definition) {
+    const source = definition && typeof definition === "object" ? definition : {};
+    const tiles = Array.isArray(source.tiles)
+        ? source.tiles
+              .map((tile) => normalizeString(tile))
+              .filter((tile) => tile.length > 0)
+        : [];
+
+    return {
+        tiles,
+    };
+}
+
+function normalizeRequest(rawRequest = null) {
+    if (!rawRequest || typeof rawRequest !== "object") {
+        return { headers: {} };
+    }
+
+    const headers = rawRequest.headers && typeof rawRequest.headers === "object"
+        ? Object.entries(rawRequest.headers).reduce((acc, [key, value]) => {
+            const normalizedKey = normalizeString(key);
+            const normalizedValue = normalizeString(value);
+            if (normalizedKey && normalizedValue) acc[normalizedKey] = normalizedValue;
+            return acc;
+        }, {})
+        : {};
+
+    return { headers };
+}
+
+function normalizeAuth(rawAuth = null) {
+    if (!rawAuth || typeof rawAuth !== "object") {
+        return { mode: "" };
+    }
+
+    return {
+        mode: normalizeString(rawAuth.mode).toLowerCase(),
+    };
+}
+
+function normalizeVisibleColumns(rawColumns = []) {
+    if (!Array.isArray(rawColumns)) return [];
+
+    return rawColumns
+        .map((column) => {
+            if (!column) return null;
+
+            if (typeof column === "string") {
+                return { id: column, name: column, format: "" };
+            }
+
+            if (typeof column === "object") {
+                const id = normalizeId(column.id || column.key || column.value);
+                if (!id) return null;
+
+                return {
+                    id,
+                    name: normalizeString(column.name || column.label, id),
+                    format: normalizeString(column.format),
+                    ...column,
+                };
+            }
+
+            return null;
+        })
+        .filter((column) => column !== null);
+}
+
+function normalizeRenderState(rawRenderState = null) {
+    if (!rawRenderState || typeof rawRenderState !== "object") return null;
+
+    const renderState = {
+        ...rawRenderState,
+    };
+
+    if (!renderState.styleExpressions || typeof renderState.styleExpressions !== "object") {
+        return null;
+    }
+
+    return renderState;
+}
+
+function normalizeLegendMode(rawLegendMode) {
+    const mode = normalizeString(rawLegendMode, "external").toLowerCase();
+    if (["internal", "external", "none"].includes(mode)) return mode;
+    return "external";
+}
+
+function normalizeBoolean(value, fallback = true) {
+    if (typeof value === "boolean") return value;
+    if (value === "true") return true;
+    if (value === "false") return false;
+    return fallback;
+}
+
+function normalizeNumber(value, fallback = null) {
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed)) return parsed;
+    }
+    return fallback;
+}
+
+function normalizeVectorTileDefinition(rawDefinition) {
+    const source = normalizeSource(rawDefinition.source);
+    const tileUrl = source.tiles[0] || "";
+
+    return {
+        id: normalizeId(rawDefinition.id),
+        type: "vector-tile",
+        source: {
+            ...source,
+            tiles: [tileUrl],
+        },
+        sourceLayer: normalizeSourceLayer(rawDefinition.sourceLayer),
+        attribution: normalizeString(rawDefinition.attribution, ""),
+        visibleColumns: normalizeVisibleColumns(rawDefinition.visibleColumns || []),
+        legendMode: normalizeLegendMode(rawDefinition.legendMode),
+        renderState: normalizeRenderState(rawDefinition.renderState),
+        request: normalizeRequest(rawDefinition.request),
+        auth: normalizeAuth(rawDefinition.auth),
+        name: normalizeString(rawDefinition.name, normalizeId(rawDefinition.id)),
+        visible: normalizeBoolean(rawDefinition.visible, true),
+        opacity: normalizeNumber(rawDefinition.opacity, null),
+        order: normalizeNumber(rawDefinition.order, null),
+    };
+}
+
+export function normalizePublicLayerPatch(rawPatch = {}) {
+    if (!rawPatch || typeof rawPatch !== "object") return {};
+
+    const patch = {};
+
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "name")) {
+        patch.name = normalizeString(rawPatch.name);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "source")) {
+        patch.source = normalizeSource(rawPatch.source);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "sourceLayer")) {
+        patch.sourceLayer = normalizeSourceLayer(rawPatch.sourceLayer);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "attribution")) {
+        patch.attribution = normalizeString(rawPatch.attribution, "");
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "visibleColumns")) {
+        patch.visibleColumns = normalizeVisibleColumns(rawPatch.visibleColumns || []);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "legendMode")) {
+        patch.legendMode = normalizeLegendMode(rawPatch.legendMode);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "renderState")) {
+        patch.renderState = normalizeRenderState(rawPatch.renderState);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "request")) {
+        patch.request = normalizeRequest(rawPatch.request);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "visible")) {
+        patch.visible = normalizeBoolean(rawPatch.visible, true);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "opacity")) {
+        patch.opacity = normalizeNumber(rawPatch.opacity, null);
+    }
+    if (Object.prototype.hasOwnProperty.call(rawPatch, "order")) {
+        patch.order = normalizeNumber(rawPatch.order, null);
+    }
+
+    return patch;
+}
+
+export function applyPublicLayerPatch(definition, rawPatch = {}) {
+    const patch = normalizePublicLayerPatch(rawPatch);
+    const merged = {
+        ...definition,
+        ...patch,
+        source: patch.source ? { ...definition.source, ...patch.source } : definition.source,
+    };
+
+    if (definition.type === "vector-tile") {
+        assertVectorTileSourceLayer(merged);
+    }
+
+    return merged;
+}
+
+function assertVectorTileSourceLayer(definition) {
+    if (!definition.id) {
+        throw new Error("La definición requiere un id de capa válido.");
+    }
+
+    if (!definition.source || definition.source.tiles.length === 0) {
+        throw new Error(
+            `La capa ${definition.id} debe incluir source.tiles con al menos una URL válida de tiles.`,
+        );
+    }
+}
+
+export function normalizePublicLayerDefinition(rawDefinition) {
+    const type = normalizeString(rawDefinition && rawDefinition.type).toLowerCase();
+
+    switch (type) {
+        case "vector-tile": {
+            const definition = normalizeVectorTileDefinition(rawDefinition);
+            assertVectorTileSourceLayer(definition);
+            return definition;
+        }
+        default: {
+            throw new Error(
+                `Tipo de capa no soportado por addLayer: ${rawDefinition && rawDefinition.type}`,
+            );
+        }
+    }
+}
+
+export function buildVectorTileLayerPayload(normalizedLayerDefinition) {
+    return {
+        layer_id: normalizedLayerDefinition.id,
+        layer: {
+            id: normalizedLayerDefinition.id,
+            name: normalizedLayerDefinition.name,
+            sh_map_has_layer_code: DYNAMIC_VECTOR_TILE_CODE,
+            sh_map_has_layer_type: "vector-tile",
+            sh_map_has_layer_url: normalizedLayerDefinition.source.tiles[0],
+            sh_map_has_layer_attribution: normalizedLayerDefinition.attribution,
+            visible_columns: normalizedLayerDefinition.visibleColumns,
+            entity_type_id: "",
+            sh_map_has_layer_vector_source_layer: normalizedLayerDefinition.sourceLayer,
+            sh_map_has_layer_legend_mode: normalizedLayerDefinition.legendMode,
+            sh_map_has_layer_render_state: normalizedLayerDefinition.renderState,
+            sh_map_request_headers: normalizedLayerDefinition.request?.headers || {},
+            sh_map_request_auth_mode: normalizedLayerDefinition.auth?.mode || "",
+            sh_map_has_layer_visible: normalizedLayerDefinition.visible,
+            sh_map_has_layer_opacity: normalizedLayerDefinition.opacity,
+        },
+        visible_columns: normalizedLayerDefinition.visibleColumns,
+        entity_type_id: "",
+        visible: normalizedLayerDefinition.visible,
+        order: normalizedLayerDefinition.order,
+        opacity: normalizedLayerDefinition.opacity,
+        _dynamic: true,
+        _uid: null,
+    };
+}
+
+export const DYNAMIC_LAYER_TYPES = Object.freeze({
+    VECTOR_TILE: "vector-tile",
+});


### PR DESCRIPTION
## Resumen
- Agrega soporte para capas dinámicas normalizadas mediante `src/utils/dynamicLayers.js`.
- Permite que `SheetsMap` reciba capas vector tile con estado de render modificable en caliente.
- Actualiza `VectorTileLayer` para usar auth runtime, `transformRequest` y cambios de estilo sin remontar la capa.
- Expone contratos públicos de acciones de mapa con payload único y readiness de configuración para que `layout_orchestrator` coordine runtime channels sin depender de delays.
- Estabiliza el viewport inicial eliminando el placeholder del Pacífico Sur, protegiendo `getMapConfiguration()` contra contextos inválidos y haciendo que `flyTo` finalice en el centro/zoom solicitado.

## Referencia
- Trabajo funcional: ANASAC01-59
- Issue GitHub: no se encontró issue asociado con `ANASAC01-59` en este repositorio.

## Diagrama
```mermaid
flowchart LR
    A[Sheets / Runtime channels] --> B[layout_orchestrator]
    B --> C{Map ready?}
    C -->|actions + config ready| D[SheetsMap mapActions]
    D --> E[dynamicLayers.js]
    D --> F[flyTo / layer actions]
    E --> G[VectorTileLayer.vue]
    G --> H[transformRequest]
    H --> I[Bearer runtime]
    G --> J[Vector tiles protegidos]
```

## Cambios principales
| Archivo | Cambio |
|---|---|
| `src/utils/dynamicLayers.js` | Normaliza definición de capas, headers, auth y render state. |
| `src/components/SheetsMap.vue` | Expone API para agregar/remover capas, aplicar render state, contratos de acciones, readiness de configuración y viewport estable. |
| `src/components/layers/VectorTileLayer.vue` | Consume Bearer runtime y aplica estilos dinámicos sin recrear la capa. |

## Cambios recientes de estabilización
- `SheetsMap.mapActions` ahora publica `contracts`, `getContracts()` e `isConfigurationReady()`.
- Las acciones públicas usan payload único: `flyTo({ latLng, zoom, options })`, `setZoom({ level })`, `drawShape({ shape })`.
- `getMapConfiguration()` valida contexto antes de pedir configuración y emite `map-configuration-ready` aunque no pueda cargar configuración.
- `flyTo` respeta `options.showMarker === false` y asegura el zoom/centro objetivo al terminar la animación.
- Se elimina el centro placeholder del Pacífico Sur para evitar contaminación del estado inicial.

## Exclusiones intencionales
- `src/App.vue` no fue incluido por instrucción explícita / cambios locales no relacionados.
- `.atl/` no fue incluido.
- `PR.md` no fue incluido.

## Validación
- [x] Se validó la generación de HTML/render state desde OGP en backend.
- [x] Se verificó que los cambios seleccionados son solo los solicitados.
- [x] `npm run build:lib` ejecutado correctamente en `sheets_map`.
- [x] `npm run dev:clean` ejecutado correctamente en `sheets_local_map` consumidor.

## Nota
Este PR es consumido por `sheets` para entregar credenciales/runtime channels y por `anasac01_backend` para publicar render state y acciones OGP genéricas.