### PR TITLE
fix(base-map): corregir zoom global y bordes vectoriales

### DIFF
--- a/src/components/SheetsMap.vue
+++ b/src/components/SheetsMap.vue
@@ -67,14 +67,14 @@
                         )?.[0]
                         "></l-tile-layer> -->
                 <template v-if="!toolbar_hide_base_layer">
-                    <l-tile-layer v-if="base_google_map" :key="'base-google-' + base_layer_key" :url="base_google_map.sh_map_has_layer_url" :attribution="'&copy; ' +
+                    <l-tile-layer v-if="base_google_map" :key="'base-google-' + base_layer_key + '-' + base_tile_options_revision" :url="base_google_map.sh_map_has_layer_url" :attribution="'&copy; ' +
                         base_google_map.sh_map_has_layer_url.match('^.*?([^:/]/)')?.[0]
-                        "></l-tile-layer>
-                    <l-tile-layer v-else-if="base_map_guide" :key="'base-guide-' + base_layer_key" :url="base_map_guide.sh_map_has_layer_url" :attribution="'&copy; ' +
+                        " :options="baseGoogleMapOptions"></l-tile-layer>
+                    <l-tile-layer v-else-if="base_map_guide" :key="'base-guide-' + base_layer_key + '-' + base_tile_options_revision" :url="base_map_guide.sh_map_has_layer_url" :attribution="'&copy; ' +
                         base_map_guide.sh_map_has_layer_url.match('^.*?([^:/]/)')?.[0]
-                        "></l-tile-layer>
-                    <l-tile-layer v-else-if="!hide_base_layer" :key="'base-default-' + base_layer_key" :url="default_base_layer" :attribution="default_attribution"
-                        :options="{ maxNativeZoom: 19, maxZoom: 20 }"></l-tile-layer>
+                        " :options="baseMapGuideOptions"></l-tile-layer>
+                    <l-tile-layer v-else-if="!hide_base_layer" :key="'base-default-' + base_layer_key + '-' + base_tile_options_revision" :url="default_base_layer" :attribution="default_attribution"
+                        :options="defaultBaseLayerOptions"></l-tile-layer>
                 </template>
 
                 <supercluster-entity-type-layer v-for="layer in supercluster_by_entity_type_layers" :key="layer.id"

--- a/src/components/layers/VectorTileLayer.vue
+++ b/src/components/layers/VectorTileLayer.vue
@@ -364,6 +364,7 @@ export default {
                 polygonFillOpacityExpression: resolvedStyleExpressions.polygonFillOpacityExpression ?? 0.6,
                 polygonStrokeWidthExpression: resolvedStyleExpressions.polygonStrokeWidthExpression ?? 2,
                 polygonStrokeOpacityExpression: resolvedStyleExpressions.polygonStrokeOpacityExpression ?? 0.8,
+                polygonBorderEnabled: resolvedStyleExpressions.polygonBorderEnabled !== false,
                 lineWidthExpression: resolvedStyleExpressions.lineWidthExpression ?? 2.5,
                 lineOpacityExpression: resolvedStyleExpressions.lineOpacityExpression ?? 0.85,
                 useSymbolForPointShape: Boolean(
@@ -374,6 +375,21 @@ export default {
                 defaultFillColor: resolvedStyleExpressions.defaultFillColor || '#3388ff',
                 defaultStrokeColor: resolvedStyleExpressions.defaultStrokeColor || '#3388ff',
             };
+        },
+
+        shouldRenderPolygonBorder(paint) {
+            if (!paint || paint.polygonBorderEnabled === false) return false;
+
+            if (typeof paint.polygonStrokeWidthExpression === 'number') {
+                return paint.polygonStrokeWidthExpression > 0;
+            }
+
+            if (typeof paint.polygonStrokeWidthExpression === 'string') {
+                const parsedStrokeWidth = Number(paint.polygonStrokeWidthExpression);
+                return !Number.isFinite(parsedStrokeWidth) || parsedStrokeWidth > 0;
+            }
+
+            return true;
         },
 
         setPaintPropertyIfExists(layerId, property, value) {
@@ -394,9 +410,14 @@ export default {
             this.setPaintPropertyIfExists(`${this.layer.id}-fill`, 'fill-color', paint.fillColorExpression);
             this.setPaintPropertyIfExists(`${this.layer.id}-fill`, 'fill-opacity', paint.polygonFillOpacityExpression);
 
-            this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-color', paint.strokeColorExpression);
-            this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-width', paint.polygonStrokeWidthExpression);
-            this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-opacity', paint.polygonStrokeOpacityExpression);
+            if (this.shouldRenderPolygonBorder(paint)) {
+                this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-color', paint.strokeColorExpression);
+                this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-width', paint.polygonStrokeWidthExpression);
+                this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-opacity', paint.polygonStrokeOpacityExpression);
+            } else {
+                this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-width', 0);
+                this.setPaintPropertyIfExists(`${this.layer.id}-line-border`, 'line-opacity', 0);
+            }
 
             this.setPaintPropertyIfExists(`${this.layer.id}-line`, 'line-color', paint.fillColorExpression);
             this.setPaintPropertyIfExists(`${this.layer.id}-line`, 'line-width', paint.lineWidthExpression);
@@ -756,19 +777,23 @@ export default {
                 }
             });
             
-            // Capa para bordes de polígonos
-            layers.push({
-                id: `${this.layer.id}-line-border`,
-                type: 'line',
-                source: 'vector-tiles',
-                'source-layer': this.sourceLayer,
-                filter: ['==', '$type', 'Polygon'],
-                paint: {
-                    'line-color': paint.strokeColorExpression,
-                    'line-width': paint.polygonStrokeWidthExpression,
-                    'line-opacity': paint.polygonStrokeOpacityExpression
-                }
-            });
+            // Capa para bordes de polígonos.
+            // Si se desactiva, no se agrega al estilo para evitar que se vean
+            // los cortes internos que produce el clipping de cada vector tile.
+            if (this.shouldRenderPolygonBorder(paint)) {
+                layers.push({
+                    id: `${this.layer.id}-line-border`,
+                    type: 'line',
+                    source: 'vector-tiles',
+                    'source-layer': this.sourceLayer,
+                    filter: ['==', '$type', 'Polygon'],
+                    paint: {
+                        'line-color': paint.strokeColorExpression,
+                        'line-width': paint.polygonStrokeWidthExpression,
+                        'line-opacity': paint.polygonStrokeOpacityExpression
+                    }
+                });
+            }
 
             // Capa para líneas standalone (calles, ríos, etc.)
             // Usa fillColorExpression para que coincida con la leyenda


### PR DESCRIPTION
## Ticket

Jira: https://coderhub.atlassian.net/browse/ANASAC01-83
Relacionado: https://coderhub.atlassian.net/browse/ANASAC01-98

## Resumen ejecutivo

Esta PR corrige dos puntos del visor usados por OGP/BigFrut:

- Las capas base ahora reciben correctamente la configuración global de zoom, evitando que el satelital quede gris al superar el zoom nativo disponible.
- Las capas vectoriales pueden desactivar el borde interno de polígonos cuando el backend lo indica, evitando líneas/seams visibles entre cortes de vector tiles.

## Qué se implementa

- Propagación de opciones globales hacia las capas base Google, MapGuide y fallback.
- Re-render seguro de capas base mediante `base_tile_options_revision`.
- Soporte para `polygonBorderEnabled: false` en `VectorTileLayer`.
- Omisión de la capa `${layer.id}-line-border` cuando el borde está desactivado o el ancho de borde es `0`.
- Actualización defensiva de paint properties cuando la capa de borde no existe.

## Arquitectura de alto nivel

```mermaid
flowchart TD
    Backend[Backend OGP] -->|map config: maxZoom / maxNativeZoom| SheetsMap[SheetsMap]
    SheetsMap --> BaseLayers[Capas base]
    Backend -->|styleExpressions polygonBorderEnabled=false| VectorTileLayer[VectorTileLayer]
    VectorTileLayer --> Fill[fill layer]
    VectorTileLayer -. omite si corresponde .-> Border[line-border]
    VectorTileLayer --> Lines[line layer]
```

## Flujo principal

```mermaid
sequenceDiagram
    participant OGP as Backend OGP
    participant SM as SheetsMap
    participant VT as VectorTileLayer
    participant ML as MapLibre

    OGP->>SM: Envía configuración global de mapa
    SM->>SM: Aplica opciones a capa base activa
    OGP->>VT: Envía styleExpressions de capa métrica
    VT->>VT: Evalúa polygonBorderEnabled/ancho de borde
    alt borde desactivado
        VT->>ML: Crea fill/line sin line-border
    else borde activo
        VT->>ML: Crea fill + line-border + line
    end
```

## Archivos principales para revisar

| Área | Archivos | Qué revisar |
|---|---|---|
| Capas base | `src/components/SheetsMap.vue` | Wiring de opciones globales y revisión del key de capas base. |
| Vector tiles | `src/components/layers/VectorTileLayer.vue` | Condición para renderizar u omitir `line-border`. |

## Estrategia de revisión sugerida

1. Revisar primero `SheetsMap.vue` para confirmar que `maxZoom`/`maxNativeZoom` llegan a las capas base.
2. Revisar `VectorTileLayer.vue` para validar que el borde de polígonos se pueda apagar sin romper líneas reales.
3. Probar visualmente zoom satelital y capas OGP con polígonos métricos.

## Validación ejecutada

- `npm run build:lib`
  - Resultado: compilación OK.

## Riesgos y puntos de atención

- Si una capa nace con `polygonBorderEnabled=false`, no se crea `line-border`; si otro consumidor quisiera reactivar bordes dinámicamente en la misma instancia, debería recrear la capa o forzar reload.
- El ajuste de zoom depende de que el backend mande `maxZoom=23` y `maxNativeZoom=18` como configuración global del mapa/base layer.

## Checklist

- [x] Implementación incluida.
- [x] Build de librería ejecutado.
- [x] Descripción en español.
- [x] Diagrama Mermaid incluido para facilitar revisión.
