### PR TITLE
fix(map-actions): separar flyTo del marcador de ubicación

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ this.$refs.sheetsMap.mapActions.zoomIn();
 | `setZoom`                | `setZoom(level)`           | Establecer un nivel de zoom específico (0–20)                      |
 | `getZoom`                | `getZoom()`                | Obtener el nivel de zoom actual                                    |
 | `flyTo`                  | `flyTo(latLng, zoom?)`     | Volar a `{ lat, lng }` con zoom opcional (default 12)              |
+| `teleportTo`             | `teleportTo(latLng, zoom?)` | Centrar el mapa sin animación ni marcador de geolocalización       |
 | `panTo`                  | `panTo(latLng)`            | Centrar el mapa en `{ lat, lng }` sin animación                    |
 | `filterByBounds`         | `filterByBounds()`         | Filtrar datos por zona visible del mapa                            |
 | `toggleCoordinateFormat` | `toggleCoordinateFormat()` | Alternar formato de coordenadas (latlng / UTM)                     |

--- a/src/components/SheetsMap.vue
+++ b/src/components/SheetsMap.vue
@@ -790,7 +790,7 @@ export default {
                 },
                 /** Obtener el nivel de zoom actual */
                 getZoom: () => this.zoom,
-                /** Volar a una ubicación { lat, lng } con zoom opcional (default 12) */
+                /** Volar a una ubicación { lat, lng } con zoom opcional (default 12). No crea marcador salvo options.showMarker=true. */
                 flyTo: (payload = {}) =>
                     payload?.latLng
                         ? this.zoomToLocation(
@@ -813,6 +813,7 @@ export default {
                         this.external_view_override = true;
                     }
 
+                    this.clearLocationMarker();
                     this.center = latLng;
                     this.zoom = zoom;
                     if (this.map) {
@@ -1721,9 +1722,13 @@ export default {
 
             this.$delete(this.vector_tile_legends, layerId);
         },
-        zoomToLocation(latLng, zoom) {
-            this.setMarker(latLng.lat, latLng.lng);
-            this.map.flyTo(latLng, zoom || 12);
+        zoomToLocation(latLng, zoom, options = {}) {
+            if (options.showMarker === true) {
+                this.setMarker(latLng.lat, latLng.lng);
+            } else {
+                this.clearLocationMarker();
+            }
+            this.map.flyTo(latLng, zoom || 12, options.leaflet || {});
         },
         zoomMap(zoom) {
             if (zoom === "out") this.zoom--;
@@ -1812,15 +1817,18 @@ export default {
          * El ícono cambia entre pin rojo (zoom < 15) y crosshair (zoom >= 15).
          */
         setMarker(lat, lng) {
-            if (this.marker) {
-                this.map.removeLayer(this.marker);
-                this.marker = null;
-            }
+            this.clearLocationMarker();
 
             const zoom = this.map ? this.map.getZoom() : this.zoom;
             const icon = this.getMarkerIconForZoom(zoom);
 
             this.marker = L.marker([lat, lng], { icon }).addTo(this.map);
+        },
+
+        clearLocationMarker() {
+            if (!this.marker) return;
+            this.map.removeLayer(this.marker);
+            this.marker = null;
         },
 
         /**

--- a/src/components/SheetsMap.vue
+++ b/src/components/SheetsMap.vue
@@ -717,6 +717,18 @@ export default {
                         },
                     },
                 },
+                teleportTo: {
+                    invocation: { type: "payload" },
+                    required: ["latLng"],
+                    payload: {
+                        latLng: "LatLng",
+                        zoom: "number",
+                        options: {
+                            externalOverride: "boolean",
+                            leaflet: "object",
+                        },
+                    },
+                },
                 panTo: {
                     invocation: { type: "payload" },
                     required: ["latLng"],
@@ -787,6 +799,26 @@ export default {
                               payload?.options || {},
                           )
                         : undefined,
+                /** Teletransportar el mapa a { lat, lng } sin crear marcador de geolocalización */
+                teleportTo: (payload = {}) => {
+                    const latLng = payload?.latLng;
+                    const options = payload?.options || {};
+                    if (!latLng) return;
+
+                    const maxZoom = this.map_max_zoom ?? DEFAULT_ACTION_MAX_ZOOM;
+                    const requestedZoom = typeof payload?.zoom === "number" ? payload.zoom : this.zoom;
+                    const zoom = Math.max(0, Math.min(maxZoom, requestedZoom));
+
+                    if (options.externalOverride !== false) {
+                        this.external_view_override = true;
+                    }
+
+                    this.center = latLng;
+                    this.zoom = zoom;
+                    if (this.map) {
+                        this.map.setView(latLng, zoom, options.leaflet || {});
+                    }
+                },
                 /** Centrar el mapa en { lat, lng } sin animación */
                 panTo: (payload = {}) => {
                     const latLng = payload?.latLng;


### PR DESCRIPTION
## Ticket

No asociado a ticket en esta PR. Cambio solicitado durante validación OGP runtime.

## Resumen ejecutivo

Esta PR separa dos comportamientos que estaban acoplados en la API pública del mapa: mover la cámara y mostrar marcador de ubicación.

Antes, `flyTo` siempre generaba el marcador rojo de ubicación. Eso provocaba que acciones como “Ajustar cuartel”, que solo necesitan recentrar el mapa, mostraran un punto rojo que semánticamente corresponde al geolocalizador del usuario.

## Qué se implementa

- Se agrega/usa `teleportTo` como acción pública para mover la vista sin animación ni marcador.
- `flyTo` deja de crear marcador por defecto.
- `flyTo` solo muestra marcador cuando recibe `options.showMarker: true`.
- Se agrega `clearLocationMarker()` para limpiar marcadores previos cuando una navegación no-geolocalizada mueve la cámara.

## Arquitectura de alto nivel

```mermaid
flowchart TD
    Consumer[Consumidor externo] --> Actions[mapActions]
    Actions --> FlyTo[flyTo]
    Actions --> Teleport[teleportTo]
    FlyTo --> Camera[Mover cámara con animación]
    FlyTo --> MarkerDecision{showMarker?}
    MarkerDecision -->|true| Marker[Mostrar marcador ubicación]
    MarkerDecision -->|false| Clear[Limpiar marcador previo]
    Teleport --> SetView[Mover cámara sin animación]
    Teleport --> Clear
```

## Flujo principal

```mermaid
sequenceDiagram
    participant T as Toolbar Sheets
    participant A as mapActions
    participant M as SheetsMap

    T->>A: flyTo({ latLng, zoom })
    A->>M: zoomToLocation(options.showMarker ausente)
    M->>M: clearLocationMarker()
    M->>M: map.flyTo(latLng, zoom)

    T->>A: flyTo({ latLng, zoom, options: { showMarker: true } })
    A->>M: zoomToLocation(showMarker=true)
    M->>M: setMarker(lat, lng)
    M->>M: map.flyTo(latLng, zoom)
```

## Archivos principales para revisar

| Área | Archivos | Qué revisar |
|---|---|---|
| API pública mapa | `src/components/SheetsMap.vue` | Contrato de `flyTo`, `teleportTo` y manejo explícito del marcador. |
| Documentación | `README.md` | Referencia de acción pública agregada en la rama. |

## Validación ejecutada

- No se ejecutó build local desde esta sesión.
- Validación funcional esperada:
  - `flyTo` sin `showMarker` no debe mostrar punto rojo.
  - `flyTo` con `options.showMarker: true` debe conservar comportamiento del geolocalizador.
  - `teleportTo` debe mover cámara sin marcador.

## Riesgos y puntos de atención

- Consumidores que dependieran implícitamente de que `flyTo` siempre dejara marcador deben pasar `options.showMarker: true` explícitamente.
- Este cambio hace el contrato más claro: marcador solo cuando el consumidor lo pide.

## Checklist

- [x] Implementación incluida.
- [x] Commits con formato convencional.
- [x] Contrato público documentado en el cuerpo de la PR.
- [ ] Build/validación visual pendiente de ejecución final.