### PR TITLE
fix(map): vértice fantasma al borrar polígono + silenciar warning $li…

### DIFF
--- a/src/components/PolygonDrafter.vue
+++ b/src/components/PolygonDrafter.vue
@@ -320,9 +320,17 @@ export default {
         this._lastShape = this._prevShape;
         this._prevShape = null;
         this.setCursor("crosshair");
-        if (this.map && this.map.pm) {
-          this.map.pm.enableDraw(this._lastShape, this.draft_style);
-        }
+        // Diferir enableDraw a un macrotask: cuando el eraser se apaga porque
+        // se borró el último polígono, esto corre DENTRO del ciclo del click
+        // de borrado. Armar el dibujo sincrónico hace que geoman capture ese
+        // mismo click como primer vértice del nuevo polígono. Con setTimeout(0)
+        // el click termina antes de armar el draw -> queda activo sin vértice.
+        const shapeToDraw = this._lastShape;
+        setTimeout(() => {
+          if (this.map && this.map.pm && this.drawing && shapeToDraw) {
+            this.map.pm.enableDraw(shapeToDraw, this.draft_style);
+          }
+        }, 0);
       } else {
         // Desactivado por cancelación — limpiar sin retomar
         this._prevShape = null;

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,20 @@ import App from "./App.vue";
 import SheetsMap from "./components/SheetsMap.vue";
 import SheetsMapTools from "./components/SheetsMapTools.vue";
 
+// Fix: Vue 2.7 made $listeners readonly (backporting Vue 3 behavior where
+// listeners are merged into $attrs). BootstrapVue 2.x internally tries to
+// assign to $listeners in components like BModal, triggering a spurious
+// "[Vue warn]: $listeners is readonly" warning. Patch both Vue's warnHandler
+// and console.error to guarantee the message never reaches the browser console.
+Vue.config.warnHandler = (msg, vm, trace) => {
+    if (msg && msg.includes('$listeners is readonly')) return;
+    console.error('[Vue warn]: ' + msg + (trace || ''));
+};
+const _consoleError = console.error;
+console.error = (...args) => {
+    if (typeof args[0] === 'string' && args[0].includes('$listeners is readonly')) return;
+    _consoleError(...args);
+};
 
 // Esta seccion es importante para poder desarrollar
 // los componentes de manera aislada


### PR DESCRIPTION
…steners

src/components/PolygonDrafter.vue:
- Al apagar el eraser tras borrar el último polígono, enableDraw corría síncrono dentro del click de borrado y geoman capturaba ese click como primer vértice del nuevo polígono. Diferido a setTimeout(0) + guarda de estado (drawing) para que el click termine antes de rearmar el dibujo.

src/main.js:
- Vue 2.7 hizo $listeners readonly; BootstrapVue 2.x intenta asignarlo en BModal y genera un warn espurio "$listeners is readonly". Patch de warnHandler + console.error para silenciarlo.